### PR TITLE
Drop additional trait bounds from OctetsBuilder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "octseq"
 version = "0.1.0-dev"
 edition = "2021"
-rust_version = "0.56"
+rust-version = "1.56"
 authors = ["Martin Hoffmann <martin@nlnetlabs.nl>"]
 description = "Abstractions for types representing octet sequences."
 documentation = "https://docs.rs/octseq"

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,14 @@ impl<const N: usize> OctetsBuilder for Array<N> {
         Ok(())
     }
 
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     fn freeze(self) -> Self::Octets {
         self
     }


### PR DESCRIPTION
This PR removes the three additional trait bounds `AsRef<[u8]>`, `AsMut<[u8]>`, and `Sized` from `OctetsBuilder`.

This was already partially done in the domain version, but I realized it might be useful to drop `AsRef<[u8]>`, too. Now you can have a write-only octets builder without any ability to look back – specifically, anything `io::Write` can now be an octets builder.

Users can signal their need for more functionality such as `AsRef<[u8]>` or even `AsMut<[u8]>` by explicitly stating those trait bounds, thus ruling out certain builders.