### PR TITLE
Make OctetsFrom and OctetsInto have associated error types.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 
 use core::{cmp, fmt};
 use crate::traits::{
-    EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder,
+    EmptyBuilder, FromBuilder, IntoBuilder, OctetsBuilder, OctetsFrom,
     ShortBuf, Truncate,
 };
 
@@ -168,6 +168,17 @@ impl<const N: usize> FromBuilder for Array<N> {
 
     fn from_builder(builder: Self::Builder) -> Self {
         builder
+    }
+}
+
+
+//--- OctetsFrom
+
+impl<const N: usize, Source: AsRef<[u8]>> OctetsFrom<Source> for Array<N> {
+    type Error = ShortBuf;
+
+    fn try_octets_from(source: Source) -> Result<Self, Self::Error> {
+        Self::try_from(source.as_ref())
     }
 }
 


### PR DESCRIPTION
This PR allows implementations of `OctetsFrom` and `OctetsInto` to choose their own error type. The primary motivation is to allow types where the conversion can’t fail to use `Infallible` and provide variations of the conversion methods that then simply don’t fail.

Thus, the PR also prefixes the names of the primary methods of the two traits with `try_` and adds new `try_`-less methods that are only available when conversion can’t fail.