### PR TITLE
Add parse functions for large integer types.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,6 +6,7 @@
 
 use core::fmt;
 use super::traits::OctetsRef;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 //------------ Parser --------------------------------------------------------
 
@@ -286,6 +287,44 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
         let mut res = [0; 4];
         self.parse_buf(&mut res)?;
         Ok(u32::from_be_bytes(res))
+    }
+
+    /// Takes a `u64` from the beginning of the parser.
+    ///
+    /// The value is converted from network byte order into the system’s own
+    /// byte order if necessary. The parser is advanced by four octets. If
+    /// there aren’t enough octets left, leaves the parser untouched and
+    /// returns an error instead.
+    pub fn parse_u64(&mut self) -> Result<u64, ShortInput> {
+        let mut res = [0; 8];
+        self.parse_buf(&mut res)?;
+        Ok(u64::from_be_bytes(res))
+    }
+
+    /// Takes a [`Ipv4Addr`] from the beginning of the parser.
+    ///
+    /// The value is created using a constructor from [`Ipv4Addr`]. The parser
+    /// is advanced by four octets. If there aren't enough octets left, leaves
+    /// the parser untouched and returns an error instead.
+    pub fn parse_ipv4addr(&mut self) -> Result<Ipv4Addr, ShortInput> {
+        self.check_len(4)?;
+        Ok(Ipv4Addr::new(
+                self.parse_u8()?,
+                self.parse_u8()?,
+                self.parse_u8()?,
+                self.parse_u8()?,
+        ))
+    }
+
+    /// Takes a [`Ipv6Addr`] from the beginning of the parser.
+    ///
+    /// The value is created using a constructor from [`Ipv6Addr`]. The parser
+    /// is advanced by sixteen octets. If there aren't enough octets left,
+    /// leaves the parser untouched and returns an error instead.
+    pub fn parse_ipv6addr(&mut self) -> Result<Ipv6Addr, ShortInput> {
+        let mut buf = [0u8; 16];
+        self.parse_buf(&mut buf)?;
+        Ok(buf.into())
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -289,6 +289,18 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
         Ok(u32::from_be_bytes(res))
     }
 
+    /// Takes an `i64` from the beginning of the parser.
+    ///
+    /// The value is converted from network byte order into the system’s own
+    /// byte order if necessary. The parser is advanced by eight octets. If
+    /// there aren’t enough octets left, leaves the parser untouched and
+    /// returns an error instead.
+    pub fn parse_i64(&mut self) -> Result<i64, ShortInput> {
+        let mut res = [0; 8];
+        self.parse_buf(&mut res)?;
+        Ok(i64::from_be_bytes(res))
+    }
+
     /// Takes a `u64` from the beginning of the parser.
     ///
     /// The value is converted from network byte order into the system’s own
@@ -299,6 +311,30 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
         let mut res = [0; 8];
         self.parse_buf(&mut res)?;
         Ok(u64::from_be_bytes(res))
+    }
+
+    /// Takes a `i128` from the beginning of the parser.
+    ///
+    /// The value is converted from network byte order into the system’s own
+    /// byte order if necessary. The parser is advanced by sixteen octets. If
+    /// there aren’t enough octets left, leaves the parser untouched and
+    /// returns an error instead.
+    pub fn parse_i128(&mut self) -> Result<i128, ShortInput> {
+        let mut res = [0; 16];
+        self.parse_buf(&mut res)?;
+        Ok(i128::from_be_bytes(res))
+    }
+
+    /// Takes a `u128` from the beginning of the parser.
+    ///
+    /// The value is converted from network byte order into the system’s own
+    /// byte order if necessary. The parser is advanced by sixteen octets. If
+    /// there aren’t enough octets left, leaves the parser untouched and
+    /// returns an error instead.
+    pub fn parse_u128(&mut self) -> Result<u128, ShortInput> {
+        let mut res = [0; 16];
+        self.parse_buf(&mut res)?;
+        Ok(u128::from_be_bytes(res))
     }
 
     /// Takes a [`Ipv4Addr`] from the beginning of the parser.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -306,6 +306,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     /// The value is created using a constructor from [`Ipv4Addr`]. The parser
     /// is advanced by four octets. If there aren't enough octets left, leaves
     /// the parser untouched and returns an error instead.
+    #[cfg(feature = "std")] 
     pub fn parse_ipv4addr(&mut self) -> Result<Ipv4Addr, ShortInput> {
         self.check_len(4)?;
         Ok(Ipv4Addr::new(
@@ -321,6 +322,7 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
     /// The value is created using a constructor from [`Ipv6Addr`]. The parser
     /// is advanced by sixteen octets. If there aren't enough octets left,
     /// leaves the parser untouched and returns an error instead.
+    #[cfg(feature = "std")] 
     pub fn parse_ipv6addr(&mut self) -> Result<Ipv6Addr, ShortInput> {
         let mut buf = [0u8; 16];
         self.parse_buf(&mut buf)?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,7 +6,6 @@
 
 use core::fmt;
 use super::traits::OctetsRef;
-use std::net::{Ipv4Addr, Ipv6Addr};
 
 //------------ Parser --------------------------------------------------------
 
@@ -335,34 +334,6 @@ impl<Ref: AsRef<[u8]>> Parser<Ref> {
         let mut res = [0; 16];
         self.parse_buf(&mut res)?;
         Ok(u128::from_be_bytes(res))
-    }
-
-    /// Takes a [`Ipv4Addr`] from the beginning of the parser.
-    ///
-    /// The value is created using a constructor from [`Ipv4Addr`]. The parser
-    /// is advanced by four octets. If there aren't enough octets left, leaves
-    /// the parser untouched and returns an error instead.
-    #[cfg(feature = "std")] 
-    pub fn parse_ipv4addr(&mut self) -> Result<Ipv4Addr, ShortInput> {
-        self.check_len(4)?;
-        Ok(Ipv4Addr::new(
-                self.parse_u8()?,
-                self.parse_u8()?,
-                self.parse_u8()?,
-                self.parse_u8()?,
-        ))
-    }
-
-    /// Takes a [`Ipv6Addr`] from the beginning of the parser.
-    ///
-    /// The value is created using a constructor from [`Ipv6Addr`]. The parser
-    /// is advanced by sixteen octets. If there aren't enough octets left,
-    /// leaves the parser untouched and returns an error instead.
-    #[cfg(feature = "std")] 
-    pub fn parse_ipv6addr(&mut self) -> Result<Ipv6Addr, ShortInput> {
-        let mut buf = [0u8; 16];
-        self.parse_buf(&mut buf)?;
-        Ok(buf.into())
     }
 }
 


### PR DESCRIPTION
For routecore we need these three things. If we agree this should be in octseq, I'll add tests. Perhaps the IpAddr parsers can be in bit more efficient.