### PR TITLE
Various changes from implementation experience.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@
 #[macro_use]
 extern crate std;
 
-pub use self::traits::*;
 pub use self::parse::*;
+pub use self::traits::*;
+pub use self::types::*;
 
 pub mod traits;
 pub mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -16,7 +16,7 @@ use super::traits::Octets;
 /// the position beyond processed data.
 ///
 /// [octets reference]: trait.OctetsRef.html
-#[derive(Debug)]
+#[derive(Copy, Debug)]
 pub struct Parser<'a, Octs: ?Sized> {
     /// The underlying octets reference.
     octets: &'a Octs,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -16,7 +16,7 @@ use super::traits::Octets;
 /// the position beyond processed data.
 ///
 /// [octets reference]: trait.OctetsRef.html
-#[derive(Copy, Debug)]
+#[derive(Debug)]
 pub struct Parser<'a, Octs: ?Sized> {
     /// The underlying octets reference.
     octets: &'a Octs,
@@ -323,6 +323,9 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parser<'a, Octs> {
     }
 }
 
+
+//--- Clone and Copy
+
 impl<'a, Octs: ?Sized> Clone for Parser<'a, Octs> {
     fn clone(&self) -> Self {
         Parser {
@@ -332,6 +335,8 @@ impl<'a, Octs: ?Sized> Clone for Parser<'a, Octs> {
         }
     }
 }
+
+impl<'a, Octs: ?Sized> Copy for Parser<'a, Octs> { }
 
 
 //--------- ShortInput -------------------------------------------------------

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -36,7 +36,7 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
     /// Creates a new parser atop a reference to an octet sequence.
     pub fn from_ref(octets: &'a Octs) -> Self
     where
-        Octs: Octets,
+        Octs: AsRef<[u8]>,
     {
         Parser {
             pos: 0,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -166,17 +166,6 @@ impl<A: smallvec::Array<Item = u8>> Octets for smallvec::SmallVec<A> {
 }
 
 
-//------------ Split ---------------------------------------------------------
-
-pub trait Split {
-    fn split(&mut self, mid: usize) -> Self;
-}
-
-impl Octets for [u8] {
-    fn split(&mut self, mid: usize) -> &[u8]
-}
-
-
 //------------ Truncate ------------------------------------------------------
 
 /// An octet sequence that can be shortened.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -360,10 +360,20 @@ pub trait OctetsBuilder {
 
     /// The type of the error that happens when appending data fails.
     ///
+    /// The only error that is allowed to happen is that the builder does
+    /// not have enough space available to append the data. This case is
+    /// covered by [`ShortBuf`] which should be used by octets builders that
+    /// have limited space.
+    ///
     /// For types, such as `Vec<u8>` or `BytesMut` where appending never
     /// fails (other than with an out-of-memory panic), this should be
     /// `Infallible` (or `!` when that becomes stable).
-    type AppendError;
+    ///
+    /// `ShortBuf` has an `impl From<Infallible>`, so requiring
+    /// `Into<ShortBuf>` as a trait bound covers those two types. Doing so
+    /// avoids complicated trait bounds in types being generic over octets
+    /// builders, even if it might seem a bit strange at first.
+    type AppendError: Into<ShortBuf>;
 
     /// Appends the content of a slice to the builder.
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -166,6 +166,17 @@ impl<A: smallvec::Array<Item = u8>> Octets for smallvec::SmallVec<A> {
 }
 
 
+//------------ Split ---------------------------------------------------------
+
+pub trait Split {
+    fn split(&mut self, mid: usize) -> Self;
+}
+
+impl Octets for [u8] {
+    fn split(&mut self, mid: usize) -> &[u8]
+}
+
+
 //------------ Truncate ------------------------------------------------------
 
 /// An octet sequence that can be shortened.
@@ -694,6 +705,14 @@ impl<A: smallvec::Array<Item = u8>> FromBuilder for smallvec::SmallVec<A> {
 /// [octets builder]: trait.OctetsBuilder.html
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ShortBuf;
+
+//--- From
+
+impl From<Infallible> for ShortBuf {
+    fn from(_: Infallible) -> ShortBuf {
+        unreachable!()
+    }
+}
 
 //--- Display and Error
 


### PR DESCRIPTION
This PR collects a number of changes that seemed to make sense when using `octseq` with `domain`.

We’ll likely split this up into smaller PRs before merging.