### PR TITLE
Redesign error handling in OctetsBuilder.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@
 #[macro_use]
 extern crate std;
 
-pub use self::traits::*;
 pub use self::parse::*;
+pub use self::traits::*;
+pub use self::types::*;
 
 pub mod traits;
 pub mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,8 +26,9 @@ pub struct Parser<'a, Octs: ?Sized> {
 
     /// The length of the octets sequence.
     ///
-    /// This starts out as the length of the underlying sequence but can be
-    /// artificially shortened to limit the length of the parser.
+    /// This starts out as the length of the underlying sequence and is kept
+    /// here to be able to temporarily limit the allowed length for
+    /// `parse_blocks`.
     len: usize,
 }
 
@@ -322,6 +323,9 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parser<'a, Octs> {
     }
 }
 
+
+//--- Clone and Copy
+
 impl<'a, Octs: ?Sized> Clone for Parser<'a, Octs> {
     fn clone(&self) -> Self {
         Parser {
@@ -333,7 +337,6 @@ impl<'a, Octs: ?Sized> Clone for Parser<'a, Octs> {
 }
 
 impl<'a, Octs: ?Sized> Copy for Parser<'a, Octs> { }
-
 
 
 //--------- ShortInput -------------------------------------------------------


### PR DESCRIPTION
This PR changes the error handling for `OctetsBuilder`. See the trait documentation for the new strategy.