### PR TITLE
Restrict options for OctetsBuilder::BuildError<E>.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -56,7 +56,7 @@ pub trait OctetsBuilder {
     ///
     /// If appending octets to the buffer cannot result in any errors, this
     /// should just be `E`.
-    type BuildError<E>: From<E>;
+    type BuildError<E>: From<E> + Into<ShortBuild<E>>;
 
     /// The result of appending data.
     ///


### PR DESCRIPTION
This PR restricts the value of `OctetsBuilder::BuildError<E>` to always be `Into<ShortBuild<E>>`. In practice this means it’s either `E` or `ShortBuild<E>`. This is necessary to allow nested octets builder (i.e., octets builders that wrap other octets builders) because you cannot enforce this sort of thing via trait bounds – you’d need non-lifetime higher ranked trait bounds for it.