### PR TITLE
Remove lifetime argument from Parser.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #![no_std]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::uninlined_format_args)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(any(feature = "std"))]


### PR DESCRIPTION
The lifetime argument in `Parser<'a, Octs>` causes all sorts of issues when trying to have a parser be an argument to a closure. Given there is a blanket impl of `Octets` for a reference to anything that is `Octets` itself, it isn’t necessary for the parser to explicitly hold a reference. If necessary, this can be achieved via using a reference as the `Octs` type argument.