### PR TITLE
Add an BuilderAppendError type alias.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -517,7 +517,7 @@ pub fn infallible<T, E: Into<Infallible>>(src: Result<T, E>) -> T {
     }
 }
 
-/// Erases an error for a closure returninb an infallible results.
+/// Erases an error for a closure returning an infallible results.
 ///
 /// This function can be used for a sequence of operations on an infallible
 /// octets builder. By wrapping these operations in a closure, you can still

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -455,6 +455,16 @@ impl<const N: usize> FromBuilder for heapless::Vec<u8, N> {
 }
 
 
+//------------ BuilderAppendError --------------------------------------------
+
+/// A type alias resolving into the `AppendError` of an octets type’s builder.
+///
+/// This alias can be used rather than spelling out the complete litany in
+/// result types.
+pub type BuilderAppendError<Octets>
+    = <<Octets as FromBuilder>::Builder as OctetsBuilder>::AppendError;
+
+
 //============ Error Handling ================================================
 
 //------------ ShortBuf ------------------------------------------------------


### PR DESCRIPTION
This PR adds a type alias to refer to the `AppendError` of an octets type’s associated builder. Instead of having to write:

```
fn build<Octs>() -> Result<Octs, <<Octs as FromBuilder>::Builder as OctetsBuilder>::AppendError> { todo!() }
```
you can now just write

```
fn build<Octs>() -> Result<Octs, BuilderAppendError<Octs>> { todo!() }
```