### PR TITLE
Explicitly re-export select items at top level.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,10 +42,14 @@
 #[macro_use]
 extern crate std;
 
-pub use self::array::*;
-pub use self::builder::*;
-pub use self::octets::*;
-pub use self::parse::*;
+pub use self::array::Array;
+pub use self::builder::{
+    EmptyBuilder, FreezeBuilder, FromBuilder, IntoBuilder, OctetsBuilder,
+    ShortBuf, Truncate,
+};
+pub use self::octets::{Octets, OctetsFrom, OctetsInto};
+pub use self::parse::{Parser, ShortInput};
+pub use self::str::{Str, StrBuilder};
 
 pub mod array;
 pub mod builder;


### PR DESCRIPTION
This PR replaces the current wildcard re-exports at top level with explicitly selecting items to re-export.

This improves documentation but also makes the top-level items more stable.

Fixes #37.