### PR TITLE
fix lifetime for &Oct::Range

### DIFF
--- a/src/octets.rs
+++ b/src/octets.rs
@@ -42,7 +42,7 @@ pub trait Octets: AsRef<[u8]> {
 }
 
 impl<'t, T: Octets + ?Sized> Octets for &'t T {
-    type Range<'a> = <T as Octets>::Range<'a> where Self: 'a;
+    type Range<'a> = <T as Octets>::Range<'t> where Self: 'a;
 
     fn range(&self, range: impl RangeBounds<usize>) -> Self::Range<'_> {
         (*self).range(range)


### PR DESCRIPTION
For &'a <[u8] as Oct>, range(&'b self, ...) get an Oct reference with lifetime 'a instead of 'b, so it's possible to do something as following:
```
let mut name: Dname<&[u8]> = ...;
loop {
    if let Some(p) = name.parent() {
        name = p; // here p is not borrow from name, but the octets inside.
    }
}
```