### PR TITLE
Introduce with_range on Parser

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -813,6 +813,7 @@ mod test {
         check(&[1,2,3], ..2,  &[1,2]);
         check(&[1,2,3], ..=2, &[1,2,3]);
         check(&[1,2,3], (Bound::Excluded(0), Bound::Included(2)), &[2,3]);
+        check(&[1,2,3], (Bound::Excluded(1), Bound::Included(2)), &[3]);
     }
 
     #[test]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -45,6 +45,30 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
         }
     }
 
+    /// Creates a new parser atop a range of the referenced octet sequence.
+    ///
+    /// If the end of the specified range lies beyond the end of the
+    /// octets, returns an error.
+    pub fn from_ref_with_range(
+        octets: &'a Octs,
+        range: core::ops::Range<usize>
+    ) -> Result<Self, ShortInput>
+    where
+        Octs: AsRef<[u8]>
+    {
+        if range.end > octets.as_ref().len() {
+            Err(ShortInput(()))
+        } else {
+            Ok(
+                Parser {
+                    pos: range.start,
+                    len: range.end,
+                    octets
+                }
+            )
+        }
+    }
+
     /// Returns the wrapped reference to the underlying octets sequence.
     pub fn octets_ref(&self) -> &'a Octs {
         self.octets

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -797,5 +797,41 @@ mod test {
         );
         assert!(parser.parse_u128_le().is_err());
     }
+
+    #[test]
+    fn with_range() {
+        fn check<R>(octets: &[u8], range: R, expect: &[u8])
+            where R: RangeBounds<usize>
+        {
+            let parser = Parser::with_range(octets, range);
+            assert_eq!(parser.peek_all(), expect);
+        }
+
+        check(&[1,2,3], .. ,  &[1,2,3]);
+        check(&[1,2,3], 1..3, &[2,3]);
+        check(&[1,2,3], 1..,  &[2,3]);
+        check(&[1,2,3], ..2,  &[1,2]);
+        check(&[1,2,3], ..=2, &[1,2,3]);
+        check(&[1,2,3], (Bound::Excluded(0), Bound::Included(2)), &[2,3]);
+
+    }
+
+    #[test]
+    #[should_panic = "range start is out of range for octets"]
+    fn with_range_invalid_start() {
+        Parser::with_range(&[1,2,3], 3..);
+    }
+
+    #[test]
+    #[should_panic = "range end is out of range for octets"]
+    fn with_range_invalid_end() {
+        Parser::with_range(&[1,2,3], ..5);
+    }
+
+    #[test]
+    #[should_panic = "range starts at 2 but ends at 1"]
+    fn with_range_invalid_range() {
+        Parser::with_range(&[1,2,3], 2..1);
+    }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,6 +5,7 @@
 //! ref and allows to parse values from the octets.
 
 use core::fmt;
+use core::ops::Range;
 use crate::octets::Octets;
 
 //------------ Parser --------------------------------------------------------
@@ -47,25 +48,28 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
 
     /// Creates a new parser atop a range of the referenced octet sequence.
     ///
-    /// If the end of the specified range lies beyond the end of the
-    /// octets, returns an error.
-    pub fn from_ref_with_range(
-        octets: &'a Octs,
-        range: core::ops::Range<usize>
-    ) -> Result<Self, ShortInput>
+    /// # Panics
+    ///
+    /// Panics if `range` is decreasing or out of bounds.
+    pub fn with_range(octets: &'a Octs, range: Range<usize>) -> Self
     where
         Octs: AsRef<[u8]>
     {
+        if range.end < range.start  {
+            panic!(
+                "range starts at {} but ends at {}",
+                range.start, range.end
+            );
+        }
+        
         if range.end > octets.as_ref().len() {
-            Err(ShortInput(()))
-        } else {
-            Ok(
-                Parser {
-                    pos: range.start,
-                    len: range.end,
-                    octets
-                }
-            )
+            panic!("range end is out of range for octets");
+        }
+
+        Parser {
+            pos: range.start,
+            len: range.end,
+            octets
         }
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -813,7 +813,6 @@ mod test {
         check(&[1,2,3], ..2,  &[1,2]);
         check(&[1,2,3], ..=2, &[1,2,3]);
         check(&[1,2,3], (Bound::Excluded(0), Bound::Included(2)), &[2,3]);
-
     }
 
     #[test]
@@ -832,6 +831,15 @@ mod test {
     #[should_panic = "range starts at 2 but ends at 1"]
     fn with_range_invalid_range() {
         Parser::with_range(&[1,2,3], 2..1);
+    }
+
+    #[test]
+    #[should_panic = "range start is out of range for octets"]
+    fn with_range_invalid_exclusive_start_range() {
+        Parser::with_range(
+            &[1,2,3],
+            (Bound::Excluded(2), Bound::Excluded(5))
+        );
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -60,15 +60,18 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
 
         let pos = match range.start_bound() {
             Bound::Unbounded => 0,
-            Bound::Included(0) => 0,
             Bound::Included(n) => {
-                if octets_len == 0 || *n > octets_len - 1 {
+                if  *n + 1 > octets_len  {
                     panic!("range start is out of range for octets")
                 }
                 *n
             }
-            Bound::Excluded(_) => unreachable!() // not a thing for the
-                                                 // start_bound, right?
+            Bound::Excluded(n) => {
+                if  *n + 2 > octets_len  {
+                    panic!("range start is out of range for octets")
+                }
+                *n + 1
+            }
         };
 
         let len = match range.end_bound() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -46,12 +46,41 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
         }
     }
 
-    /// Creates a new parser atop a range of the referenced octet sequence.
+    /// Creates a new parser only using a range of the given octets.
     ///
     /// # Panics
     ///
     /// Panics if `range` is decreasing or out of bounds.
     pub fn with_range<R>(octets: &'a Octs, range: R) -> Self
+    where
+        Octs: AsRef<[u8]>,
+        R: RangeBounds<usize>
+    {
+        match Self::_try_with_range(octets, range) {
+            Ok(p) => p,
+            Err(e) => panic!("{}", e)
+        }
+    }
+
+    /// Creates a new parser only using a range if possible.
+    ///
+    /// If `range` is decreasing or out of bounds, returns an Error.
+    pub fn try_with_range<R>(
+        octets: &'a Octs, range: R
+    ) -> Option<Self>
+    where
+        Octs: AsRef<[u8]>,
+        R: RangeBounds<usize>
+    {
+        Self::_try_with_range(octets, range).ok()
+    }
+
+    /// Creates a new parser only using a range if possible.
+    ///
+    /// If `range` is decreasing or out of bounds, returns an Error.
+    fn _try_with_range<R>(
+        octets: &'a Octs, range: R
+    ) -> Result<Self, &'static str>
     where
         Octs: AsRef<[u8]>,
         R: RangeBounds<usize>

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -60,8 +60,9 @@ impl<'a, Octs: ?Sized> Parser<'a, Octs> {
 
         let pos = match range.start_bound() {
             Bound::Unbounded => 0,
+            Bound::Included(0) => 0,
             Bound::Included(n) => {
-                if *n > octets_len - 1 {
+                if octets_len == 0 || *n > octets_len - 1 {
                     panic!("range start is out of range for octets")
                 }
                 *n


### PR DESCRIPTION
This PR introduces a new constructor for `Parser`, similar to the existing `fn from_ref` but taking a range to initialize the parser on a subset of the octets.

It currently errors when the end of the passed range lies beyond the end of the octets, meaning passing in an open-ended range `(n..)` is not possible. Alternatively, we could accept any (open) end and limit it to the length of the octets, and not returning any error.