### PR TITLE
Fix `no_std`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["octets", "bytes", "generics"]
 license = "BSD-3-Clause"
 
 [dependencies]
-bytes    = { version = "1", optional = true }
+bytes    = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.7", optional = true }
 serde    = { version = "1", optional = true }
 smallvec = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std     = []
+std     = ["bytes/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ smallvec = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std     = ["bytes/std"]
+std     = ["bytes?/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,15 +32,10 @@
 //!   feature, provides traits and functions to more efficiently serialize
 //!   octets sequences.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-
-#[cfg(any(feature = "std"))]
-#[allow(unused_imports)] // Import macros even if unused.
-#[macro_use]
-extern crate std;
 
 pub use self::array::Array;
 pub use self::builder::{


### PR DESCRIPTION
`bytes` has a default `std` feature, preventing `no_std` usage.