### PR TITLE
Various Clippy-suggested fixes and some fallout from that.

### DIFF
--- a/src/octets.rs
+++ b/src/octets.rs
@@ -187,15 +187,15 @@ where
     }
 }
 
-#[cfg(features = "smallvec")]
+#[cfg(feature = "smallvec")]
 impl<Source, A> OctetsFrom<Source> for smallvec::SmallVec<A>
 where
-    Source: AsRef<u8>,
-    A: Array<Item = u8>,
+    Source: AsRef<[u8]>,
+    A: smallvec::Array<Item = u8>,
 {
     type Error = Infallible;
 
-    fn try_octets_from(source: Source) -> Result<Self, Self::Infallible> {
+    fn try_octets_from(source: Source) -> Result<Self, Self::Error> {
         Ok(smallvec::ToSmallVec::to_smallvec(source.as_ref()))
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -488,11 +488,7 @@ impl<'a, Octs: AsRef<[u8]> + ?Sized> Parser<'a, Octs> {
 
 impl<'a, Octs: ?Sized> Clone for Parser<'a, Octs> {
     fn clone(&self) -> Self {
-        Parser {
-            octets: self.octets,
-            pos: self.pos,
-            len: self.len
-        }
+        *self
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -173,12 +173,6 @@ impl<Octets: AsRef<[u8]> + ?Sized> borrow::Borrow<str> for Str<Octets>{
     }
 }
 
-impl<Octets: AsRef<[u8]> + ?Sized> borrow::Borrow<[u8]> for Str<Octets>{
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
-    }
-}
-
 impl<Octets> borrow::BorrowMut<str> for Str<Octets> 
 where Octets: AsRef<[u8]> +  AsMut<[u8]> + ?Sized {
     fn borrow_mut(&mut self) -> &mut str {
@@ -430,7 +424,7 @@ impl<Octets> StrBuilder<Octets> {
     /// Returns `None` if the builder is empty.
     pub fn pop(&mut self) -> Option<char>
     where Octets: AsRef<[u8]> + Truncate {
-        let ch = self.as_str().chars().rev().next()?;
+        let ch = self.as_str().chars().next_back()?;
         self.truncate(self.len() - ch.len_utf8());
         Some(ch)
     }
@@ -483,12 +477,6 @@ impl<Octets: AsMut<[u8]>> AsMut<str> for StrBuilder<Octets> {
 impl<Octets: AsRef<[u8]>> borrow::Borrow<str> for StrBuilder<Octets>{
     fn borrow(&self) -> &str {
         self.as_str()
-    }
-}
-
-impl<Octets: AsRef<[u8]>> borrow::Borrow<[u8]> for StrBuilder<Octets>{
-    fn borrow(&self) -> &[u8] {
-        self.as_slice()
     }
 }
 


### PR DESCRIPTION
This PR implements some changes suggested by Clippy. As a result, it actually provides an implementation of `OctetsFrom` for `Smallvec` (which was presented but never compiled due to a broken cfg attribute). It also removes the `Borrow<[u8]>` impls for `Str<_>` and `StrBuilder<_>` due to conflicts with the `Hash` impl.

Because of the latter, this is a breaking change.