### PR TITLE
Add `octseq::serde::serialize` function

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -257,24 +257,14 @@ impl<const N: usize> fmt::Debug for Array<N> {
     }
 }
 
-
-//--- SerializeOctets and DeserializeOctets
-
-#[cfg(feature = "serde")]
-impl<const N: usize> crate::serde::SerializeOctets for Array<N> {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
+//--- DeserializeOctets
 
 #[cfg(feature = "serde")]
 impl<'de, const N: usize> crate::serde::DeserializeOctets<'de> for Array<N> {
     type Visitor = ArrayVisitor<N>;
 
     fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D
+        deserializer: D,
     ) -> Result<Self, D::Error> {
         Self::visitor().deserialize(deserializer)
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -31,7 +31,7 @@ where
     Octs::deserialize_octets(deserializer)
 }
 
-//------------ OctetsSerializer --------------------------------------------
+//------------ AsSerializedOctets --------------------------------------------
 
 /// A wrapper forcing a value to serialize through its octets.
 ///

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,12 +12,20 @@ use core::fmt;
 use core::marker::PhantomData;
 use serde::de::Visitor;
 
-pub fn serialize<T, S>(octs: &T, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<Octs, S>(octs: &Octs, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
-    T: AsRef<[u8]> + ?Sized,
+    Octs: AsRef<[u8]> + ?Sized,
 {
     octs.as_ref().serialize_octets(serializer)
+}
+
+pub fn deserialize<'de, Octs, D>(deserializer: D) -> Result<Octs, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    Octs: DeserializeOctets<'de>,
+{
+    Octs::deserialize_octets(deserializer)
 }
 
 //------------ SerializeOctets -----------------------------------------------
@@ -421,4 +429,3 @@ impl<'de, const N: usize> serde::de::Visitor<'de> for HeaplessVecVisitor<N> {
         Ok(heapless::Vec::from_iter(value.iter().copied()))
     }
 }
-

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,6 +12,13 @@ use core::fmt;
 use core::marker::PhantomData;
 use serde::de::Visitor;
 
+pub fn serialize<T, S>(octs: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: AsRef<[u8]> + ?Sized,
+{
+    octs.as_ref().serialize_octets(serializer)
+}
 
 //------------ SerializeOctets -----------------------------------------------
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,21 +3,24 @@
 //! [Serde](https://serde.rs/) supports native serialization of octets
 //! sequences. However, because of missing specialization, it has to
 //! serialize the octets slices and vec as literal sequences of `u8`s. In
-//! order to allow octets sequences their own native serialization, the crate
-//! defines two traits [`SerializeOctets`] and [`DeserializeOctets`] if
-//! built with the `serde` feature enabled.
+//! order to allow octets sequences their own native deserialization, the
+//! crate defines the trait [`DeserializeOctets`] if built with the `serde`
+//! feature enabled.
 #![cfg(feature = "serde")]
 
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::Visitor;
 
-pub fn serialize<Octs, S>(octs: &Octs, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<Octs, S>(
+    octs: &Octs,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
     Octs: AsRef<[u8]> + ?Sized,
 {
-    octs.as_ref().serialize_octets(serializer)
+    serializer.serialize_bytes(octs.as_ref())
 }
 
 pub fn deserialize<'de, Octs, D>(deserializer: D) -> Result<Octs, D::Error>
@@ -28,100 +31,27 @@ where
     Octs::deserialize_octets(deserializer)
 }
 
-//------------ SerializeOctets -----------------------------------------------
-
-pub trait SerializeOctets {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error>;
-
-    fn as_serialized_octets(&self) -> AsSerializedOctets<Self> {
-        AsSerializedOctets(self)
-    }
-}
-
-impl SerializeOctets for [u8] {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self)
-    }
-}
-
-impl<'a> SerializeOctets for &'a [u8] {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl<'a> SerializeOctets for std::borrow::Cow<'a, [u8]> {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
-
-#[cfg(feature = "std")]
-impl SerializeOctets for std::vec::Vec<u8> {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
-
-#[cfg(feature = "bytes")]
-impl SerializeOctets for bytes::Bytes {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
-
-#[cfg(feature = "smallvec")]
-impl<A> SerializeOctets for smallvec::SmallVec<A>
-where A: smallvec::Array<Item = u8> {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
-
-#[cfg(feature = "heapless")]
-impl<const N: usize> SerializeOctets for heapless::Vec<u8, N> {
-    fn serialize_octets<S: serde::Serializer>(
-        &self, serializer: S
-    ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_bytes(self.as_ref())
-    }
-}
-
-
-//------------ AsSerializedOctets --------------------------------------------
+//------------ OctetsSerializer --------------------------------------------
 
 /// A wrapper forcing a value to serialize through its octets.
 ///
 /// This type can be used where a `Serialize` value is required.
-pub struct AsSerializedOctets<'a, T: ?Sized>(&'a T);
+pub struct AsSerializedOctets<'a>(&'a [u8]);
 
-impl<'a, T: SerializeOctets> serde::Serialize for AsSerializedOctets<'a, T>
-where
-    T: SerializeOctets + ?Sized
-{
+impl<'a> serde::Serialize for AsSerializedOctets<'a> {
     fn serialize<S: serde::Serializer>(
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        self.0.serialize_octets(serializer)
+        serialize(&self.0, serializer)
     }
 }
 
+impl<'a, T: AsRef<[u8]> + ?Sized> From<&'a T> for AsSerializedOctets<'a> {
+    fn from(value: &'a T) -> Self {
+        AsSerializedOctets(value.as_ref())
+    }
+}
 
 //------------ DeserializeOctets ---------------------------------------------
 
@@ -129,8 +59,10 @@ pub trait DeserializeOctets<'de>: Sized {
     type Visitor: Visitor<'de, Value = Self>;
 
     fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D
-    ) -> Result<Self, D::Error>;
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        Self::deserialize_with_visitor(deserializer, Self::visitor())
+    }
 
     fn deserialize_with_visitor<
         D: serde::Deserializer<'de>,
@@ -145,12 +77,6 @@ pub trait DeserializeOctets<'de>: Sized {
 
 impl<'de> DeserializeOctets<'de> for &'de [u8] {
     type Visitor = BorrowedVisitor<Self>;
-
-    fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
-    }
 
     fn deserialize_with_visitor<D, V>(
         deserializer: D,
@@ -175,7 +101,7 @@ impl<'de> DeserializeOctets<'de> for std::borrow::Cow<'de, [u8]> {
     fn deserialize_octets<D: serde::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
+        Self::deserialize_with_visitor(deserializer, Self::visitor())
     }
 
     fn deserialize_with_visitor<D, V>(
@@ -198,12 +124,6 @@ impl<'de> DeserializeOctets<'de> for std::borrow::Cow<'de, [u8]> {
 impl<'de> DeserializeOctets<'de> for std::vec::Vec<u8> {
     type Visitor = BufVisitor<Self>;
 
-    fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
-    }
-
     fn deserialize_with_visitor<D, V>(
         deserializer: D,
         visitor: V,
@@ -223,12 +143,6 @@ impl<'de> DeserializeOctets<'de> for std::vec::Vec<u8> {
 #[cfg(feature = "bytes")]
 impl<'de> DeserializeOctets<'de> for bytes::Bytes {
     type Visitor = BufVisitor<Self>;
-
-    fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
-    }
 
     fn deserialize_with_visitor<D, V>(
         deserializer: D,
@@ -253,12 +167,6 @@ where
 {
     type Visitor = BufVisitor<Self>;
 
-    fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
-    }
-
     fn deserialize_with_visitor<D, V>(
         deserializer: D,
         visitor: V,
@@ -278,12 +186,6 @@ where
 #[cfg(feature = "heapless")]
 impl<'de, const N: usize> DeserializeOctets<'de> for heapless::Vec<u8, N> {
     type Visitor = HeaplessVecVisitor<N>;
-
-    fn deserialize_octets<D: serde::Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Self, D::Error> {
-        Self::visitor().deserialize(deserializer)
-    }
 
     fn deserialize_with_visitor<D, V>(
         deserializer: D,
@@ -308,16 +210,6 @@ pub struct BorrowedVisitor<T>(PhantomData<T>);
 impl<T> BorrowedVisitor<T> {
     fn new() -> Self {
         BorrowedVisitor(PhantomData)
-    }
-
-    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<T, D::Error>
-    where
-        T: From<&'de [u8]>,
-    {
-        deserializer.deserialize_bytes(self)
     }
 }
 
@@ -349,16 +241,6 @@ impl<T> BufVisitor<T> {
     fn new() -> Self {
         BufVisitor(PhantomData)
     }
-
-    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<T, D::Error>
-    where
-        T: From<std::vec::Vec<u8>>,
-    {
-        deserializer.deserialize_byte_buf(self)
-    }
 }
 
 #[cfg(feature = "std")]
@@ -387,7 +269,6 @@ where
     }
 }
 
-
 //------------ HeaplessVisitor -----------------------------------------------
 
 #[cfg(feature = "heapless")]
@@ -397,13 +278,6 @@ pub struct HeaplessVecVisitor<const N: usize>;
 impl<const N: usize> HeaplessVecVisitor<N> {
     fn new() -> Self {
         Self
-    }
-
-    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
-        self,
-        deserializer: D,
-    ) -> Result<heapless::Vec<u8, N>, D::Error> {
-        deserializer.deserialize_byte_buf(self)
     }
 }
 


### PR DESCRIPTION
The idea is to light deprecate the `SerializeOctets` trait (or at least discourage its use as a bound). See also [this pr](https://github.com/NLnetLabs/domain/pull/344/files).

The name is chosen to (hopefully) provide a `deserialize` function as well allowing us to use `#[serde(with = "octseq::serde")]` at some point, simplifying the use.