### PR TITLE
Fix Array::resize_raw() to allow resizing to the length of the array.

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -42,7 +42,7 @@ impl<const N: usize> Array<N> {
     ///
     /// Returns an error if `new_len` is larger than the array size.
     pub fn resize_raw(&mut self, new_len: usize) -> Result<(), ShortBuf> {
-        if new_len >= N {
+        if new_len > N {
             Err(ShortBuf)
         }
         else {


### PR DESCRIPTION
The `new_len` parameter to Array::resize_raw() is the new length of the contained octets sequence. The documentation for resize_raw() specifies that it is an error for `new_len` to be larger than the array size, but the current code also returns an error if `new_len` is equal to the array size.

The following code will cause a panic with octseq 0.5.2, for instance if one were preparing an Array<512> buffer to receive a UDP DNS query message into.

```rust
use octseq::{array::Array, EmptyBuilder};

const UDP_DNS_QUERY_MAX_SIZE: usize = 512;

fn main() {
    let mut query_packet = Array::<UDP_DNS_QUERY_MAX_SIZE>::empty();
    query_packet.resize_raw(UDP_DNS_QUERY_MAX_SIZE).unwrap();
}
```