### PR TITLE
Fix no_std and alloc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,13 @@ license = "BSD-3-Clause"
 [dependencies]
 bytes    = { version = "1", optional = true, default-features = false }
 heapless = { version = "0.9", optional = true }
-serde    = { version = "1", optional = true }
+serde    = { version = "1", optional = true, default-features = false }
 smallvec = { version = "1", optional = true }
 
 [features]
 default = ["std"]
-std     = ["bytes?/std"]
+alloc   = ["serde?/alloc"]
+std     = ["alloc", "bytes?/std", "serde?/std"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,10 +8,13 @@ New
 
 Improvements
 
+* Made proper use of `no_std` and `alloc`. ([#68])
+
 Bug fixes
 
 Other
 
+[#68]: https://github.com/NLnetLabs/octseq/pull/68
 
 ## 0.6.0
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,9 +23,8 @@
 use core::fmt;
 use core::convert::Infallible;
 #[cfg(feature = "bytes")] use bytes::{Bytes, BytesMut};
-#[cfg(feature = "std")] use std::borrow::Cow;
-#[cfg(feature = "std")] use std::vec::Vec;
-
+#[cfg(feature = "alloc")] use alloc::borrow::Cow;
+#[cfg(feature = "alloc")] use alloc::vec::Vec;
 
 //------------ OctetsBuilder -------------------------------------------------
 
@@ -71,7 +70,7 @@ impl<'a, T: OctetsBuilder> OctetsBuilder for &'a mut T {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl OctetsBuilder for Vec<u8> {
     type AppendError = Infallible;
 
@@ -83,7 +82,7 @@ impl OctetsBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> OctetsBuilder for Cow<'a, [u8]> {
     type AppendError = Infallible;
 
@@ -93,7 +92,7 @@ impl<'a> OctetsBuilder for Cow<'a, [u8]> {
         if let Cow::Owned(ref mut vec) = *self {
             vec.extend_from_slice(slice);
         } else {
-            let mut vec = std::mem::replace(
+            let mut vec = core::mem::replace(
                 self, Cow::Borrowed(b"")
             ).into_owned();
             vec.extend_from_slice(slice);
@@ -163,7 +162,7 @@ impl<'a> Truncate for &'a [u8] {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> Truncate for Cow<'a, [u8]> {
     fn truncate(&mut self, len: usize) {
         match *self {
@@ -173,7 +172,7 @@ impl<'a> Truncate for Cow<'a, [u8]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Truncate for Vec<u8> {
     fn truncate(&mut self, len: usize) {
         self.truncate(len)
@@ -226,7 +225,7 @@ pub trait EmptyBuilder {
     fn with_capacity(capacity: usize) -> Self;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl EmptyBuilder for Vec<u8> {
     fn empty() -> Self {
         Vec::new()
@@ -284,7 +283,7 @@ pub trait FreezeBuilder {
     fn freeze(self) -> Self::Octets;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl FreezeBuilder for Vec<u8> {
     type Octets = Self;
 
@@ -293,7 +292,7 @@ impl FreezeBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> FreezeBuilder for Cow<'a, [u8]> {
     type Octets = Self;
 
@@ -341,7 +340,7 @@ pub trait IntoBuilder {
     fn into_builder(self) -> Self::Builder;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl IntoBuilder for Vec<u8> {
     type Builder = Self;
 
@@ -350,7 +349,7 @@ impl IntoBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> IntoBuilder for &'a [u8] {
     type Builder = Vec<u8>;
 
@@ -359,7 +358,7 @@ impl<'a> IntoBuilder for &'a [u8] {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> IntoBuilder for Cow<'a, [u8]> {
     type Builder = Self;
 
@@ -410,7 +409,7 @@ pub trait FromBuilder: AsRef<[u8]> + Sized {
     fn from_builder(builder: Self::Builder) -> Self;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl FromBuilder for Vec<u8> {
     type Builder = Self;
 
@@ -419,7 +418,7 @@ impl FromBuilder for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> FromBuilder for Cow<'a, [u8]> {
     type Builder = Self;
 
@@ -498,8 +497,7 @@ impl fmt::Display for ShortBuf {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ShortBuf {}
+impl core::error::Error for ShortBuf {}
 
 
 //------------ Functions for Infallible --------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! These traits are implemented for a number of types. Apart from `[u8]`,
 //! the implementations are opt-in via features. These are:
 //!
-//! * `std` for `Vec<u8>`, `Cow<[u8]>`, and `Arc<[u8]>`,
+//! * `alloc` for `Vec<u8>`, `Cow<[u8]>`, and `Arc<[u8]>`,
 //! * `bytes` for the `Bytes` and `BytesMut` types from the
 //!   [bytes](https://crates.io/crates/bytes) crate,
 //! * `heapless` for the `Vec<u8, N>` type from the
@@ -36,6 +36,9 @@
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::unknown_clippy_lints)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 pub use self::array::Array;
 pub use self::builder::{

--- a/src/octets.rs
+++ b/src/octets.rs
@@ -15,8 +15,8 @@
 use core::convert::Infallible;
 use core::ops::{Index, RangeBounds};
 #[cfg(feature = "bytes")] use bytes::{Bytes, BytesMut};
-#[cfg(feature = "std")] use std::borrow::Cow;
-#[cfg(feature = "std")] use std::vec::Vec;
+#[cfg(feature = "alloc")] use alloc::borrow::Cow;
+#[cfg(feature = "alloc")] use alloc::vec::Vec;
 use crate::builder::ShortBuf;
 
 
@@ -59,7 +59,7 @@ impl Octets for [u8] {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'c> Octets for Cow<'c, [u8]> {
     type Range<'a> = &'a [u8] where Self: 'a;
 
@@ -68,7 +68,7 @@ impl<'c> Octets for Cow<'c, [u8]> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl Octets for Vec<u8> {
     type Range<'a> = &'a [u8];
 
@@ -77,8 +77,8 @@ impl Octets for Vec<u8> {
     }
 }
 
-#[cfg(feature = "std")]
-impl Octets for std::sync::Arc<[u8]> {
+#[cfg(feature = "alloc")]
+impl Octets for alloc::sync::Arc<[u8]> {
     type Range<'a> = &'a [u8];
 
     fn range(&self, range: impl RangeBounds<usize>) -> Self::Range<'_> {
@@ -151,7 +151,7 @@ impl<'a, Source: AsRef<[u8]> + 'a> OctetsFrom<&'a Source> for &'a [u8] {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<Source> OctetsFrom<Source> for Vec<u8>
 where
     Self: From<Source>,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -499,8 +499,7 @@ impl fmt::Display for ShortInput {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ShortInput {}
+impl core::error::Error for ShortInput {}
 
 
 //============ Testing =======================================================

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -41,8 +41,8 @@ impl<'a> SerializeOctets for &'a [u8] {
     }
 }
 
-#[cfg(feature = "std")]
-impl<'a> SerializeOctets for std::borrow::Cow<'a, [u8]> {
+#[cfg(feature = "alloc")]
+impl<'a> SerializeOctets for alloc::borrow::Cow<'a, [u8]> {
     fn serialize_octets<S: serde::Serializer>(
         &self, serializer: S
     ) -> Result<S::Ok, S::Error> {
@@ -50,8 +50,8 @@ impl<'a> SerializeOctets for std::borrow::Cow<'a, [u8]> {
     }
 }
 
-#[cfg(feature = "std")]
-impl SerializeOctets for std::vec::Vec<u8> {
+#[cfg(feature = "alloc")]
+impl SerializeOctets for alloc::vec::Vec<u8> {
     fn serialize_octets<S: serde::Serializer>(
         &self, serializer: S
     ) -> Result<S::Ok, S::Error> {
@@ -153,8 +153,8 @@ impl<'de> DeserializeOctets<'de> for &'de [u8] {
     }
 }
 
-#[cfg(feature = "std")]
-impl<'de> DeserializeOctets<'de> for std::borrow::Cow<'de, [u8]> {
+#[cfg(feature = "alloc")]
+impl<'de> DeserializeOctets<'de> for alloc::borrow::Cow<'de, [u8]> {
     type Visitor = BorrowedVisitor<Self>;
 
     fn deserialize_octets<D: serde::Deserializer<'de>>(
@@ -179,8 +179,8 @@ impl<'de> DeserializeOctets<'de> for std::borrow::Cow<'de, [u8]> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<'de> DeserializeOctets<'de> for std::vec::Vec<u8> {
+#[cfg(feature = "alloc")]
+impl<'de> DeserializeOctets<'de> for alloc::vec::Vec<u8> {
     type Visitor = BufVisitor<Self>;
 
     fn deserialize_octets<D: serde::Deserializer<'de>>(
@@ -326,10 +326,10 @@ where
 
 //------------ BufVisitor ------------------------------------------------
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub struct BufVisitor<T>(PhantomData<T>);
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<T> BufVisitor<T> {
     fn new() -> Self {
         BufVisitor(PhantomData)
@@ -340,16 +340,16 @@ impl<T> BufVisitor<T> {
         deserializer: D,
     ) -> Result<T, D::Error>
     where
-        T: From<std::vec::Vec<u8>>,
+        T: From<alloc::vec::Vec<u8>>,
     {
         deserializer.deserialize_byte_buf(self)
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'de, T> serde::de::Visitor<'de> for BufVisitor<T>
 where
-    T: From<std::vec::Vec<u8>>,
+    T: From<alloc::vec::Vec<u8>>,
 {
     type Value = T;
 
@@ -361,12 +361,12 @@ where
         self,
         value: &'de [u8],
     ) -> Result<Self::Value, E> {
-        Ok(std::vec::Vec::from(value).into())
+        Ok(alloc::vec::Vec::from(value).into())
     }
 
     fn visit_byte_buf<E: serde::de::Error>(
         self,
-        value: std::vec::Vec<u8>,
+        value: alloc::vec::Vec<u8>,
     ) -> Result<Self::Value, E> {
         Ok(value.into())
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -89,9 +89,9 @@ impl Str<[u8]> {
     }
 }
 
-#[cfg(feature = "std")]
-impl Str<std::vec::Vec<u8>> {
-    pub fn from_string(s: std::string::String) -> Self {
+#[cfg(feature = "alloc")]
+impl Str<alloc::vec::Vec<u8>> {
+    pub fn from_string(s: alloc::string::String) -> Self {
         unsafe { Self::from_utf8_unchecked(s.into_bytes()) }
     }
 }
@@ -631,8 +631,7 @@ impl<Octets> fmt::Display for FromUtf8Error<Octets> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<Octets> std::error::Error for FromUtf8Error<Octets> {}
+impl<Octets> core::error::Error for FromUtf8Error<Octets> {}
 
 
 //============ Testing =======================================================
@@ -645,12 +644,12 @@ mod test {
     // of the Rust standard library.
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn from_utf8_lossy() {
         fn check(src: impl AsRef<[u8]>) {
             assert_eq!(
-                StrBuilder::from_utf8_lossy(std::vec::Vec::from(src.as_ref())),
-                std::string::String::from_utf8_lossy(src.as_ref())
+                StrBuilder::from_utf8_lossy(alloc::vec::Vec::from(src.as_ref())),
+                alloc::string::String::from_utf8_lossy(src.as_ref())
             );
         }
 
@@ -666,9 +665,9 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn push_str() {
-        let mut s = StrBuilder::<std::vec::Vec<u8>>::new();
+        let mut s = StrBuilder::<alloc::vec::Vec<u8>>::new();
         s.push_str("");
         assert_eq!(&s[0..], "");
         s.push_str("abc");
@@ -678,10 +677,10 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn push() {
         let mut data = StrBuilder::from_utf8(
-            std::vec::Vec::from("ประเทศไทย中".as_bytes())
+            alloc::vec::Vec::from("ประเทศไทย中".as_bytes())
         ).unwrap();
         data.push('华');
         data.push('b'); // 1 byte
@@ -692,10 +691,10 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn pop() {
         let mut data = StrBuilder::from_utf8(
-            std::vec::Vec::from("ประเทศไทย中华b¢€𤭢".as_bytes())
+            alloc::vec::Vec::from("ประเทศไทย中华b¢€𤭢".as_bytes())
         ).unwrap();
         assert_eq!(data.pop().unwrap(), '𤭢'); // 4 bytes
         assert_eq!(data.pop().unwrap(), '€'); // 3 bytes


### PR DESCRIPTION
The `no_std` feature was barely usable, because most of common types like `Vec` or `String` where taken from `std`.

This PR introduce a new cargo feature `alloc` that allows users to still benefit from `no_std` while using common types from `alloc` external crate. It also allows no_std users to have Error implementation (using `core` instead of `std`).

I also adjusted `serde` features to match `alloc`.

Refs: https://github.com/NLnetLabs/domain/issues/572.

